### PR TITLE
Add CLI runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,26 @@ Remember to always maintain the core principle of **mandatory human oversight** 
 - Enhanced statistical analysis tools
 - Expanded domain coverage
 
+## Command Line Interface
+
+The repository includes a lightweight CLI wrapper to run the core Mojo modules.
+The script `scripts/cli.py` forwards commands to the `mojo` executable.
+
+```bash
+python scripts/cli.py <command> [-- <mojo args>]
+```
+
+Available commands:
+
+- `workflow`  – run `academic_research_workflow.mojo`
+- `match`     – run `pattern_matcher.mojo`
+- `validate`  – run `validation_system.mojo`
+- `config`    – run `research_config.mojo`
+- `example`   – run `example_usage.mojo`
+
+Arguments after `--` are passed directly to the Mojo script. Ensure the `mojo`
+binary is installed and reachable via `PATH` or set `MOJO_BIN` before running.
+
 ## Contributing
 
 This system is designed with extensibility in mind. Researchers can contribute:

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Command line interface for Mojo Academic Research Workflow System."""
+import argparse
+import subprocess
+import os
+import sys
+
+MOJO_FILES = {
+    "workflow": "academic_research_workflow.mojo",
+    "match": "pattern_matcher.mojo",
+    "validate": "validation_system.mojo",
+    "config": "research_config.mojo",
+    "example": "example_usage.mojo",
+}
+
+MOJO_BIN = os.environ.get("MOJO_BIN", "mojo")
+
+
+def run_module(name: str, mojo_args: list[str]):
+    """Run the specified Mojo module with optional arguments."""
+    if name not in MOJO_FILES:
+        raise ValueError(f"Unknown command: {name}")
+
+    path = MOJO_FILES[name]
+    cmd = [MOJO_BIN, "run", path]
+    if mojo_args:
+        cmd.append("--")
+        cmd.extend(mojo_args)
+
+    result = subprocess.run(cmd)
+    sys.exit(result.returncode)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run Mojo research workflow modules from the command line",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for cmd_name, file in MOJO_FILES.items():
+        sub = subparsers.add_parser(cmd_name, help=f"Run {file}")
+        sub.add_argument(
+            "args",
+            nargs=argparse.REMAINDER,
+            help="Arguments passed through to the Mojo program",
+        )
+
+    args = parser.parse_args()
+    run_module(args.command, args.args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/cli.py` to run the Mojo modules from the command line
- document usage in README

## Testing
- `python3 -m py_compile scripts/cli.py`

------
https://chatgpt.com/codex/tasks/task_e_684bc20aa6b4832cbd5ea1ed138194f3